### PR TITLE
Remove :protocol pseudo-header field from responses

### DIFF
--- a/webtransport-proto/src/connect.rs
+++ b/webtransport-proto/src/connect.rs
@@ -175,7 +175,6 @@ impl ConnectResponse {
     pub fn encode<B: BufMut>(&self, buf: &mut B) {
         let mut headers = qpack::Headers::default();
         headers.set(":status", self.status.as_str());
-        headers.set(":protocol", "webtransport");
         headers.set("sec-webtransport-http3-draft", "draft02");
 
         // Use a temporary buffer so we can compute the size.


### PR DESCRIPTION
The pseudo-header field should be used only for requests. When a response contains :protocol pseudo-header, a client treats the response as invalid [1].

[1] https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/http/quic_spdy_client_stream.cc;l=210;drc=b1797e6792a78b79e22a8f8e60549684f8a4c7d9