### PR TITLE
Switch from `http::Uri` to `url::Url`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,6 +403,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +572,16 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "instant"
@@ -751,6 +770,12 @@ dependencies = [
  "base64",
  "serde",
 ]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
@@ -1275,16 +1300,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
 
 [[package]]
 name = "utf8parse"
@@ -1396,6 +1447,7 @@ dependencies = [
  "log",
  "rand",
  "tokio",
+ "url",
  "webtransport-generic",
 ]
 
@@ -1414,6 +1466,7 @@ dependencies = [
  "bytes",
  "http",
  "thiserror",
+ "url",
 ]
 
 [[package]]
@@ -1434,6 +1487,7 @@ dependencies = [
  "rustls",
  "thiserror",
  "tokio",
+ "url",
  "webtransport-baton",
  "webtransport-generic",
  "webtransport-proto",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1443,7 +1443,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytes",
- "http",
  "log",
  "rand",
  "tokio",
@@ -1455,7 +1454,6 @@ dependencies = [
 name = "webtransport-generic"
 version = "0.5.0"
 dependencies = [
- "bytes",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "webtransport-proto"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "http",
@@ -1471,7 +1471,7 @@ dependencies = [
 
 [[package]]
 name = "webtransport-quinn"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-std",

--- a/webtransport-baton/Cargo.toml
+++ b/webtransport-baton/Cargo.toml
@@ -20,7 +20,6 @@ webtransport-generic = { path = "../webtransport-generic", version = "0.5" }
 bytes = "1"
 anyhow = "1"
 rand = "0.8"
-tokio = { version = "1.27", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 log = "0.4"
-http = "0.2"
 url = "2"

--- a/webtransport-baton/Cargo.toml
+++ b/webtransport-baton/Cargo.toml
@@ -23,3 +23,4 @@ rand = "0.8"
 tokio = { version = "1.27", features = ["full"] }
 log = "0.4"
 http = "0.2"
+url = "2"

--- a/webtransport-baton/src/lib.rs
+++ b/webtransport-baton/src/lib.rs
@@ -4,21 +4,22 @@ use std::{collections::HashMap, fmt};
 
 use anyhow::Context;
 use rand::Rng;
+use url::Url;
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::task::JoinSet;
 
 use webtransport_generic::{RecvStream, SendStream, Session};
 
-pub fn parse(uri: &http::Uri) -> anyhow::Result<(u8, u16)> {
-    if uri.path() != "/webtransport/devious-baton" {
-        anyhow::bail!("invalid path: {}", uri.path());
+pub fn parse(url: &Url) -> anyhow::Result<(u8, u16)> {
+    if url.path() != "/webtransport/devious-baton" {
+        anyhow::bail!("invalid path: {}", url.path());
     }
 
     let mut query = HashMap::new();
 
     // Get the query string after the path.
-    if let Some(str) = uri.query() {
+    if let Some(str) = url.query() {
         // Split the query string into key-value pairs
         for part in str.split('&') {
             let (key, value) = part.split_once('=').context("failed to split")?;

--- a/webtransport-generic/Cargo.toml
+++ b/webtransport-generic/Cargo.toml
@@ -15,5 +15,4 @@ categories = ["network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bytes = "1"
 tokio = "1" # only includes AsyncRead and AsyncWrite; no features

--- a/webtransport-proto/Cargo.toml
+++ b/webtransport-proto/Cargo.toml
@@ -17,3 +17,4 @@ categories = ["network-programming", "web-programming"]
 http = "0.2"
 bytes = "1"
 thiserror = "1"
+url = "2"

--- a/webtransport-proto/Cargo.toml
+++ b/webtransport-proto/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/webtransport-rs"
 license = "MIT"
 
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]

--- a/webtransport-proto/src/connect.rs
+++ b/webtransport-proto/src/connect.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use bytes::{Buf, BufMut};
+use url::Url;
 
 use super::{qpack, Frame, VarInt};
 
@@ -21,11 +22,8 @@ pub enum ConnectError {
     #[error("invalid method")]
     InvalidMethod(#[from] http::method::InvalidMethod),
 
-    #[error("invalid uri")]
-    InvalidUri(#[from] http::uri::InvalidUri),
-
-    #[error("invalid uri parts")]
-    InvalidUriParts(#[from] http::uri::InvalidUriParts),
+    #[error("invalid url")]
+    InvalidUrl(#[from] url::ParseError),
 
     #[error("invalid status")]
     InvalidStatus(#[from] http::status::InvalidStatusCode),
@@ -37,7 +35,7 @@ pub enum ConnectError {
     WrongMethod(Option<http::method::Method>),
 
     #[error("expected https, got: {0:?}")]
-    WrongScheme(Option<http::uri::Scheme>),
+    WrongScheme(Option<String>),
 
     #[error("expected authority header")]
     WrongAuthority,
@@ -45,13 +43,16 @@ pub enum ConnectError {
     #[error("expected webtransport, got: {0:?}")]
     WrongProtocol(Option<String>),
 
+    #[error("expected path header")]
+    WrongPath,
+
     #[error("non-200 status: {0:?}")]
     ErrorStatus(http::StatusCode),
 }
 
 #[derive(Debug)]
 pub struct ConnectRequest {
-    pub uri: http::Uri,
+    pub url: Url,
 }
 
 impl ConnectRequest {
@@ -65,27 +66,20 @@ impl ConnectRequest {
 
         let headers = qpack::Headers::decode(&mut data)?;
 
-        let mut parts = http::uri::Parts::default();
-        parts.scheme = headers
-            .get(":scheme")
-            .map(|scheme| scheme.try_into())
-            .transpose()?;
-        parts.authority = headers
-            .get(":authority")
-            .map(|auth| auth.try_into())
-            .transpose()?;
-        parts.path_and_query = headers
-            .get(":path")
-            .map(|path| path.try_into())
-            .transpose()?;
-        let uri = http::Uri::from_parts(parts)?;
+        let scheme = match headers.get(":scheme") {
+            Some("https") => "https",
+            Some(scheme) => Err(ConnectError::WrongScheme(Some(scheme.to_string())))?,
+            None => return Err(ConnectError::WrongScheme(None)),
+        };
 
-        // Validate the headers
-        match headers
-            .get(":method")
-            .map(|method| method.try_into())
-            .transpose()?
-        {
+        let authority = headers
+            .get(":authority")
+            .ok_or(ConnectError::WrongAuthority)?;
+
+        let path = headers.get(":path").ok_or(ConnectError::WrongPath)?;
+
+        let method = headers.get(":method");
+        match method.map(|method| method.try_into()).transpose()? {
             Some(http::Method::CONNECT) => (),
             o => return Err(ConnectError::WrongMethod(o)),
         };
@@ -95,30 +89,17 @@ impl ConnectRequest {
             return Err(ConnectError::WrongProtocol(protocol.map(|s| s.to_string())));
         }
 
-        if uri.scheme() != Some(&http::uri::Scheme::HTTPS) {
-            return Err(ConnectError::WrongScheme(uri.scheme().cloned()));
-        }
+        let url = Url::parse(&format!("{}://{}{}", scheme, authority, path))?;
 
-        if uri.authority().is_none() {
-            return Err(ConnectError::WrongAuthority);
-        }
-
-        Ok(Self { uri })
+        Ok(Self { url })
     }
 
     pub fn encode<B: BufMut>(&self, buf: &mut B) {
         let mut headers = qpack::Headers::default();
         headers.set(":method", "CONNECT");
-
-        if let Some(scheme) = self.uri.scheme() {
-            headers.set(":scheme", scheme.as_str());
-        }
-
-        if let Some(host) = self.uri.authority() {
-            headers.set(":authority", host.as_str());
-        }
-
-        headers.set(":path", self.uri.path_and_query().unwrap().as_str());
+        headers.set(":scheme", self.url.scheme());
+        headers.set(":authority", self.url.authority());
+        headers.set(":path", self.url.path());
         headers.set(":protocol", "webtransport");
 
         // Use a temporary buffer so we can compute the size.

--- a/webtransport-quinn/Cargo.toml
+++ b/webtransport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/webtransport-rs"
 license = "MIT"
 
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -14,7 +14,7 @@ categories = ["network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webtransport-proto = { path = "../webtransport-proto", version = "0.5.4" }
+webtransport-proto = { path = "../webtransport-proto", version = "0.6" }
 webtransport-generic = { path = "../webtransport-generic", version = "0.5" }
 
 quinn = "0.10"

--- a/webtransport-quinn/Cargo.toml
+++ b/webtransport-quinn/Cargo.toml
@@ -23,18 +23,18 @@ quinn-proto = "0.10"
 http = "0.2"
 thiserror = "1"
 futures = "0.3"
-async-std = "1.11"
+async-std = "1"
 url = "2"
 
 # This is just for AsyncRead/AsyncWrite and does NOT pull in anything else
-tokio = "1.29"
+tokio = "1"
 
 [dev-dependencies]
 webtransport-baton = { path = "../webtransport-baton", version = "0.1" }
 rcgen = "0.11"
 anyhow = "1"
-tokio = { version = "1.27", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 env_logger = "0.10"
-clap = { version = "4.3", features = ["derive"] }
+clap = { version = "4", features = ["derive"] }
 log = "0.4"

--- a/webtransport-quinn/Cargo.toml
+++ b/webtransport-quinn/Cargo.toml
@@ -24,6 +24,7 @@ http = "0.2"
 thiserror = "1"
 futures = "0.3"
 async-std = "1.11"
+url = "2"
 
 # This is just for AsyncRead/AsyncWrite and does NOT pull in anything else
 tokio = "1.29"

--- a/webtransport-quinn/examples/client.rs
+++ b/webtransport-quinn/examples/client.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use url::Url;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -8,7 +9,7 @@ struct Args {
         long,
         default_value = "https://localhost:4443/webtransport/devious-baton"
     )]
-    uri: http::Uri,
+    url: Url,
 }
 
 #[tokio::main]
@@ -36,10 +37,10 @@ async fn main() -> anyhow::Result<()> {
     //	Create the WebTransport URL.
     let batons = 1;
 
-    log::info!("connecting to {}", args.uri);
+    log::info!("connecting to {}", args.url);
 
-    // Connect to the given URI.
-    let session = webtransport_quinn::connect(&client, &args.uri).await?;
+    // Connect to the given URL.
+    let session = webtransport_quinn::connect(&client, &args.url).await?;
 
     // Run the baton code.
     webtransport_baton::run(session, None, batons).await?;

--- a/webtransport-quinn/examples/server.rs
+++ b/webtransport-quinn/examples/server.rs
@@ -66,10 +66,10 @@ async fn run_conn(conn: quinn::Connecting) -> anyhow::Result<()> {
 
     // Perform the WebTransport handshake.
     let request = webtransport_quinn::accept(conn).await?;
-    log::info!("received WebTransport request: {}", request.uri());
+    log::info!("received WebTransport request: {}", request.url());
 
-    // Parse the request URI to decide if we should accept the session.
-    let (initial, count) = match webtransport_baton::parse(request.uri()) {
+    // Parse the request URL to decide if we should accept the session.
+    let (initial, count) = match webtransport_baton::parse(request.url()) {
         Ok(v) => v,
         Err(err) => {
             log::info!("invalid request: {}", err);

--- a/webtransport-quinn/src/client.rs
+++ b/webtransport-quinn/src/client.rs
@@ -1,5 +1,6 @@
 use async_std::net::ToSocketAddrs;
 use thiserror::Error;
+use url::Url;
 
 use crate::{Connect, ConnectError, Session, Settings, SettingsError};
 
@@ -31,49 +32,46 @@ pub enum ClientError {
     InvalidDnsName(String),
 }
 
-/// Connect to a WebTransport server at the given URI.
-/// The URI must be of the form `https://host:port/path` or else the server will reject it.
+/// Connect to a WebTransport server at the given URL.
+/// The UR: must be of the form `https://host:port/path` or else the server will reject it.
 /// Returns a [`Session`] which is a wrapper over [`quinn::Connection`].
-pub async fn connect(client: &quinn::Endpoint, uri: &http::Uri) -> Result<Session, ClientError> {
-    let authority = uri
-        .authority()
-        .ok_or(ClientError::InvalidDnsName("".to_string()))?;
-
+pub async fn connect(client: &quinn::Endpoint, url: &Url) -> Result<Session, ClientError> {
     // TODO error on username:password in host
-    let host = authority.host();
-    let port = authority.port().map(|p| p.as_u16()).unwrap_or(443);
+    let host = url
+        .host()
+        .ok_or_else(|| ClientError::InvalidDnsName("".to_string()))?
+        .to_string();
+
+    let port = url.port().unwrap_or(443);
 
     // Look up the DNS entry.
-    let mut remotes = match (host, port).to_socket_addrs().await {
+    let mut remotes = match (host.as_str(), port).to_socket_addrs().await {
         Ok(remotes) => remotes,
-        Err(_) => return Err(ClientError::InvalidDnsName(host.to_string())),
+        Err(_) => return Err(ClientError::InvalidDnsName(host)),
     };
 
     // Return the first entry.
     let remote = match remotes.next() {
         Some(remote) => remote,
-        None => return Err(ClientError::InvalidDnsName(host.to_string())),
+        None => return Err(ClientError::InvalidDnsName(host)),
     };
 
     // Connect to the server using the addr we just resolved.
-    let conn = client.connect(remote, host)?;
+    let conn = client.connect(remote, &host)?;
     let conn = conn.await?;
 
     // Connect with the connection we established.
-    connect_with(conn, uri).await
+    connect_with(conn, url).await
 }
 
 /// Connect using an established QUIC connection if you want to create the connection yourself.
 /// This will only work with a brand new QUIC connection using the HTTP/3 ALPN.
-pub async fn connect_with(
-    conn: quinn::Connection,
-    uri: &http::Uri,
-) -> Result<Session, ClientError> {
+pub async fn connect_with(conn: quinn::Connection, url: &Url) -> Result<Session, ClientError> {
     // Perform the H3 handshake by sending/reciving SETTINGS frames.
     let settings = Settings::connect(&conn).await?;
 
     // Send the HTTP/3 CONNECT request.
-    let connect = Connect::open(&conn, uri).await?;
+    let connect = Connect::open(&conn, url).await?;
 
     // Return the resulting session with a reference to the control/connect streams.
     // If either stream is closed, then the session will be closed, so we need to keep them around.

--- a/webtransport-quinn/src/connect.rs
+++ b/webtransport-quinn/src/connect.rs
@@ -3,6 +3,7 @@ use std::io;
 use webtransport_proto::{ConnectRequest, ConnectResponse, VarInt};
 
 use thiserror::Error;
+use url::Url;
 
 #[derive(Error, Debug)]
 pub enum ConnectError {
@@ -87,12 +88,12 @@ impl Connect {
         Ok(())
     }
 
-    pub async fn open(conn: &quinn::Connection, uri: &http::Uri) -> Result<Self, ConnectError> {
+    pub async fn open(conn: &quinn::Connection, url: &Url) -> Result<Self, ConnectError> {
         // Create a new stream that will be used to send the CONNECT frame.
         let (mut send, mut recv) = conn.open_bi().await?;
 
         // Create a new CONNECT request that we'll send using HTTP/3
-        let request = ConnectRequest { uri: uri.clone() };
+        let request = ConnectRequest { url: url.clone() };
 
         // Encode our connect request into a buffer and write it to the stream.
         let mut buf = Vec::new();
@@ -145,8 +146,8 @@ impl Connect {
         VarInt::try_from(stream_id.into_inner()).unwrap()
     }
 
-    // The URI in the CONNECT request.
-    pub fn uri(&self) -> &http::Uri {
-        &self.request.uri
+    // The URL in the CONNECT request.
+    pub fn url(&self) -> &Url {
+        &self.request.url
     }
 }

--- a/webtransport-quinn/src/server.rs
+++ b/webtransport-quinn/src/server.rs
@@ -1,6 +1,7 @@
 use crate::{Connect, ConnectError, Session, Settings, SettingsError};
 
 use thiserror::Error;
+use url::Url;
 
 /// An error returned when receiving a new WebTransport session.
 #[derive(Error, Debug)]
@@ -25,7 +26,7 @@ pub enum ServerError {
 }
 
 /// Accept a new WebTransport session from a client.
-/// Returns a [`Request`] which is then used to accept or reject the session based on the URI.
+/// Returns a [`Request`] which is then used to accept or reject the session based on the URL.
 pub async fn accept(conn: quinn::Connection) -> Result<Request, ServerError> {
     // Perform the H3 handshake by sending/reciving SETTINGS frames.
     let settings = Settings::connect(&conn).await?;
@@ -41,7 +42,7 @@ pub async fn accept(conn: quinn::Connection) -> Result<Request, ServerError> {
     })
 }
 
-/// A mostly complete WebTransport handshake, just awaiting the server's decision on whether to accept or reject the session based on the URI.
+/// A mostly complete WebTransport handshake, just awaiting the server's decision on whether to accept or reject the session based on the URL.
 pub struct Request {
     conn: quinn::Connection,
     settings: Settings,
@@ -49,9 +50,9 @@ pub struct Request {
 }
 
 impl Request {
-    /// Returns the URI provided by the client.
-    pub fn uri(&self) -> &http::Uri {
-        self.connect.uri()
+    /// Returns the URL provided by the client.
+    pub fn url(&self) -> &Url {
+        self.connect.url()
     }
 
     /// Accept the session, returning a 200 OK.


### PR DESCRIPTION
We depend on the `http` package already, but the `Uri` struct is just awful to use.