### PR TITLE
echo server example will only respond once the send stream is closed

### DIFF
--- a/webtransport-quinn/examples/echo-client.rs
+++ b/webtransport-quinn/examples/echo-client.rs
@@ -70,6 +70,9 @@ async fn main() -> anyhow::Result<()> {
     send.write_all(msg.as_bytes()).await?;
     log::info!("sent: {}", msg);
 
+    // Shut down the send stream.
+    send.finish().await?;
+
     // Read back the message.
     let msg = recv.read_to_end(1024).await?;
     log::info!("recv: {}", String::from_utf8_lossy(&msg));


### PR DESCRIPTION
I don't actually want to merge this PR, i want to use it to illustrate a possible issue.

The rust client example currently fails with a timeout.  The server accepts a bi-directional stream from the client, but hangs waiting to read from the receive stream. 

In this PR, in the client example, we call [`.finish()`](https://docs.rs/quinn/0.10.2/quinn/struct.SendStream.html#method.finish) on the send stream before waiting for a response on the receive stream. This causes the server to actually receive the message, and it then responds echoing the message.

The `web` client example also closes the send stream before waiting to see the echoed response: https://github.com/kixelated/webtransport-rs/blob/3153f826549bfa04a220e89c8798f37b822dc39f/webtransport-quinn/web/client.js#L57 which explains why the web example works fine.

However, this is not the normal behaviour of Quinn - usually bi-directional streams allow both parties to send and receive data when the stream is open. 

I have no idea why this is happening here, it could be something to do with the session mutex.
