### PR TITLE
webtransport-proto: Require url >=2.4.0

### DIFF
--- a/webtransport-proto/Cargo.toml
+++ b/webtransport-proto/Cargo.toml
@@ -17,4 +17,4 @@ categories = ["network-programming", "web-programming"]
 http = "0.2"
 bytes = "1"
 thiserror = "1"
-url = "2"
+url = "^2.4.0"


### PR DESCRIPTION
This version added the authority method, so earlier ones don't actually work