### PR TITLE
Don't use AsyncRead/Write for webtransport_generic.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "quictransport-quinn"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "quinn",
@@ -1127,10 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "webtransport-generic"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
- "tokio",
 ]
 
 [[package]]
@@ -1145,7 +1144,7 @@ dependencies = [
 
 [[package]]
 name = "webtransport-quinn"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/quictransport-quinn/Cargo.toml
+++ b/quictransport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/webtransport-rs"
 license = "MIT"
 
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -14,7 +14,7 @@ categories = ["network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-webtransport-generic = { path = "../webtransport-generic", version = "0.8" }
+webtransport-generic = { path = "../webtransport-generic", version = "0.9" }
 
 quinn = "0.10"
 

--- a/quictransport-quinn/src/error.rs
+++ b/quictransport-quinn/src/error.rs
@@ -37,8 +37,8 @@ impl fmt::Debug for SessionError {
 
 impl Error for SessionError {}
 
-impl webtransport_generic::SessionError for SessionError {
-    fn session_error(&self) -> Option<u32> {
+impl webtransport_generic::ErrorCode for SessionError {
+    fn code(&self) -> Option<u32> {
         match &self.0 {
             quinn::ConnectionError::ApplicationClosed(msg) => {
                 msg.error_code.into_inner().try_into().ok()

--- a/quictransport-quinn/src/send.rs
+++ b/quictransport-quinn/src/send.rs
@@ -1,4 +1,11 @@
-use std::{ops, pin::Pin};
+use std::{
+    error::Error,
+    fmt,
+    future::Future,
+    ops,
+    pin::{pin, Pin},
+    task::{ready, Context, Poll},
+};
 
 use quinn::VarInt;
 use tokio::io::AsyncWrite;
@@ -50,11 +57,79 @@ impl AsyncWrite for SendStream {
 }
 
 impl webtransport_generic::SendStream for SendStream {
-    fn set_priority(&mut self, order: i32) {
+    type Error = WriteError;
+
+    fn priority(&mut self, order: i32) {
         quinn::SendStream::set_priority(self, order).ok();
     }
 
-    fn reset(&mut self, code: u32) {
-        quinn::SendStream::reset(self, VarInt::from_u32(code)).ok();
+    fn close(mut self, code: u32) {
+        quinn::SendStream::reset(&mut self, VarInt::from_u32(code)).ok();
+    }
+
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+        pin!(quinn::SendStream::write(self, buf))
+            .poll(cx)
+            .map(|res| res.map_err(Into::into))
+    }
+
+    fn poll_write_buf<B: bytes::Buf>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>> {
+        Poll::Ready(match ready!(self.poll_write(cx, buf.chunk())) {
+            Ok(n) => {
+                buf.advance(n);
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct WriteError(quinn::WriteError);
+
+impl From<quinn::WriteError> for WriteError {
+    fn from(error: quinn::WriteError) -> Self {
+        WriteError(error)
+    }
+}
+
+impl ops::Deref for WriteError {
+    type Target = quinn::WriteError;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl ops::DerefMut for WriteError {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Error for WriteError {}
+
+impl fmt::Debug for WriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::Display for WriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl webtransport_generic::ErrorCode for WriteError {
+    fn code(&self) -> Option<u32> {
+        match &self.0 {
+            quinn::WriteError::Stopped(code) => TryInto::<u32>::try_into(code.into_inner()).ok(),
+            _ => None,
+        }
     }
 }

--- a/webtransport-generic/Cargo.toml
+++ b/webtransport-generic/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley", "François Michel"]
 repository = "https://github.com/kixelated/webtransport-rs"
 license = "MIT OR Apache-2.0"
 
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -15,5 +15,4 @@ categories = ["network-programming", "web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1", default-features = false }
 bytes = "1"

--- a/webtransport-generic/src/error.rs
+++ b/webtransport-generic/src/error.rs
@@ -1,0 +1,7 @@
+use std::error::Error;
+use std::fmt::Debug;
+
+// An error that optionally contains a QUIC error code.
+pub trait ErrorCode: Error + Debug + Send + Sync + 'static {
+    fn code(&self) -> Option<u32>;
+}

--- a/webtransport-generic/src/lib.rs
+++ b/webtransport-generic/src/lib.rs
@@ -1,7 +1,9 @@
+mod error;
 mod recv;
 mod send;
 mod session;
 
+pub use error::*;
 pub use recv::*;
 pub use send::*;
 pub use session::*;

--- a/webtransport-generic/src/recv.rs
+++ b/webtransport-generic/src/recv.rs
@@ -1,7 +1,40 @@
-use tokio::io::AsyncRead;
+use std::{
+    future::{poll_fn, Future},
+    task::{Context, Poll},
+};
+
+use bytes::{BufMut, Bytes};
+
+use crate::ErrorCode;
 
 /// A trait describing the "receive" actions of a QUIC stream.
-pub trait RecvStream: AsyncRead + Unpin + Send {
+pub trait RecvStream: Unpin + Send {
+    type Error: ErrorCode;
+
     /// Send a `STOP_SENDING` QUIC code.
-    fn stop(&mut self, error_code: u32);
+    fn close(self, code: u32);
+
+    /// Attempt to read from the stream into the given buffer.
+    fn poll_read_buf<B: BufMut>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>>;
+
+    // A helper future that calls poll_read_buf.
+    fn read_buf<B: BufMut + Send>(
+        &mut self,
+        buf: &mut B,
+    ) -> impl Future<Output = Result<usize, Self::Error>> + Send {
+        poll_fn(move |cx| self.poll_read_buf(cx, buf))
+    }
+
+    /// Attempt to write the given buffer to the stream.
+    fn poll_read_chunk(&mut self, cx: &mut Context<'_>)
+        -> Poll<Result<Option<Bytes>, Self::Error>>;
+
+    // A helper future that calls poll_read_chunk.
+    fn read_chunk(&mut self) -> impl Future<Output = Result<Option<Bytes>, Self::Error>> + Send {
+        poll_fn(|cx| self.poll_read_chunk(cx))
+    }
 }

--- a/webtransport-generic/src/send.rs
+++ b/webtransport-generic/src/send.rs
@@ -1,12 +1,45 @@
-use tokio::io::AsyncWrite;
+use std::{
+    future::{poll_fn, Future},
+    task::{Context, Poll},
+};
+
+use bytes::Buf;
+
+use crate::ErrorCode;
 
 /// A trait describing the "send" actions of a QUIC stream.
-pub trait SendStream: AsyncWrite + Unpin + Send {
-    /// Send a QUIC reset code.
-    fn reset(&mut self, reset_code: u32);
+pub trait SendStream: Unpin + Send {
+    type Error: ErrorCode;
 
     /// Set the stream's priority relative to other streams on the same connection.
     /// The **highest** priority stream with pending data will be sent first.
     /// Zero is the default value.
-    fn set_priority(&mut self, order: i32);
+    fn priority(&mut self, order: i32);
+
+    /// Send a QUIC reset code.
+    fn close(self, code: u32);
+
+    /// Attempt to write some of the given buffer to the stream.
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>>;
+
+    // A helper future that calls poll_write
+    fn write(&mut self, buf: &[u8]) -> impl Future<Output = Result<usize, Self::Error>> + Send {
+        poll_fn(|cx| self.poll_write(cx, buf))
+    }
+
+    fn poll_write_buf<B: Buf>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>>;
+
+    // A helper future that calls poll_write
+    fn write_buf<B: Buf + Send>(
+        &mut self,
+        buf: &mut B,
+    ) -> impl Future<Output = Result<usize, Self::Error>> + Send {
+        poll_fn(|cx| self.poll_write_buf(cx, buf))
+    }
+
+    // TODO add write_chunk to avoid making a copy?
 }

--- a/webtransport-generic/src/session.rs
+++ b/webtransport-generic/src/session.rs
@@ -1,10 +1,7 @@
-use std::error::Error;
 use std::future::{poll_fn, Future};
-
-use std::fmt::Debug;
 use std::task::{Context, Poll};
 
-use super::{RecvStream, SendStream};
+use crate::{ErrorCode, RecvStream, SendStream};
 
 /// Trait representing a WebTransport session.
 ///
@@ -13,7 +10,7 @@ use super::{RecvStream, SendStream};
 pub trait Session: Clone + Send + Sync + Unpin {
     type SendStream: SendStream;
     type RecvStream: RecvStream;
-    type Error: SessionError;
+    type Error: ErrorCode;
 
     /// Accept an incoming unidirectional stream
     fn poll_accept_uni(&self, cx: &mut Context<'_>) -> Poll<Result<Self::RecvStream, Self::Error>>;
@@ -84,10 +81,4 @@ pub trait Session: Clone + Send + Sync + Unpin {
     fn recv_datagram(&self) -> impl Future<Output = Result<bytes::Bytes, Self::Error>> + Send {
         poll_fn(|cx| self.poll_recv_datagram(cx))
     }
-}
-
-/// Trait that represent an error from the transport layer
-pub trait SessionError: Error + Send + Sync + Debug + 'static {
-    /// Get the QUIC error code from CONNECTION_CLOSE
-    fn session_error(&self) -> Option<u32>;
 }

--- a/webtransport-quinn/Cargo.toml
+++ b/webtransport-quinn/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/kixelated/webtransport-rs"
 license = "MIT"
 
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 
 keywords = ["quic", "http3", "webtransport"]
@@ -15,7 +15,7 @@ categories = ["network-programming", "web-programming"]
 
 [dependencies]
 webtransport-proto = { path = "../webtransport-proto", version = "0.6" }
-webtransport-generic = { path = "../webtransport-generic", version = "0.8" }
+webtransport-generic = { path = "../webtransport-generic", version = "0.9" }
 
 quinn = "0.10"
 bytes = "1"

--- a/webtransport-quinn/src/error.rs
+++ b/webtransport-quinn/src/error.rs
@@ -26,9 +26,9 @@ pub enum WebTransportError {
     WriteError(#[from] quinn::WriteError),
 }
 
-impl webtransport_generic::SessionError for SessionError {
+impl webtransport_generic::ErrorCode for SessionError {
     // Get the app error code from a CONNECTION_CLOSE
-    fn session_error(&self) -> Option<u32> {
+    fn code(&self) -> Option<u32> {
         match self {
             SessionError::ConnectionError(quinn::ConnectionError::ApplicationClosed(app)) => {
                 webtransport_proto::error_from_http3(app.error_code.into_inner())
@@ -70,11 +70,11 @@ impl From<quinn::WriteError> for WriteError {
     }
 }
 
-impl webtransport_generic::SessionError for WriteError {
+impl webtransport_generic::ErrorCode for WriteError {
     // Get the app error code from a CONNECTION_CLOSE
-    fn session_error(&self) -> Option<u32> {
+    fn code(&self) -> Option<u32> {
         match self {
-            WriteError::SessionError(e) => e.session_error(),
+            WriteError::Stopped(code) => Some(*code),
             _ => None,
         }
     }
@@ -116,11 +116,11 @@ impl From<quinn::ReadError> for ReadError {
     }
 }
 
-impl webtransport_generic::SessionError for ReadError {
+impl webtransport_generic::ErrorCode for ReadError {
     // Get the app error code from a CONNECTION_CLOSE
-    fn session_error(&self) -> Option<u32> {
+    fn code(&self) -> Option<u32> {
         match self {
-            ReadError::SessionError(e) => e.session_error(),
+            ReadError::Reset(code) => Some(*code),
             _ => None,
         }
     }

--- a/webtransport-quinn/src/lib.rs
+++ b/webtransport-quinn/src/lib.rs
@@ -26,15 +26,17 @@
 // External
 mod client;
 mod error;
+mod recv;
+mod send;
 mod server;
 mod session;
-mod stream;
 
 pub use client::*;
 pub use error::*;
+pub use recv::*;
+pub use send::*;
 pub use server::*;
 pub use session::*;
-pub use stream::*;
 
 // Internal
 mod connect;

--- a/webtransport-quinn/src/recv.rs
+++ b/webtransport-quinn/src/recv.rs
@@ -1,0 +1,116 @@
+use std::{
+    io,
+    pin::{pin, Pin},
+    task::{ready, Context, Poll},
+};
+
+use bytes::Bytes;
+use futures::Future;
+
+use crate::{ReadError, ReadExactError, ReadToEndError};
+
+/// A stream that can be used to recieve bytes. See [`quinn::RecvStream`].
+#[derive(Debug)]
+pub struct RecvStream {
+    inner: quinn::RecvStream,
+}
+
+impl RecvStream {
+    pub(crate) fn new(stream: quinn::RecvStream) -> Self {
+        Self { inner: stream }
+    }
+
+    /// Tell the other end to stop sending data with the given error code. See [`quinn::RecvStream::stop`].
+    /// This is a u32 with WebTransport since it shares the error space with HTTP/3.
+    pub fn stop(&mut self, code: u32) -> Result<(), quinn::UnknownStream> {
+        let code = webtransport_proto::error_to_http3(code);
+        let code = quinn::VarInt::try_from(code).unwrap();
+        self.inner.stop(code)
+    }
+
+    // Unfortunately, we have to wrap ReadError for a bunch of functions.
+
+    /// Read some data into the buffer and return the amount read. See [`quinn::RecvStream::read`].
+    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, ReadError> {
+        self.inner.read(buf).await.map_err(Into::into)
+    }
+
+    /// Fill the entire buffer with data. See [`quinn::RecvStream::read_exact`].
+    pub async fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ReadExactError> {
+        self.inner.read_exact(buf).await.map_err(Into::into)
+    }
+
+    /// Read a chunk of data from the stream. See [`quinn::RecvStream::read_chunk`].
+    pub async fn read_chunk(
+        &mut self,
+        max_length: usize,
+        ordered: bool,
+    ) -> Result<Option<quinn::Chunk>, ReadError> {
+        self.inner
+            .read_chunk(max_length, ordered)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Read chunks of data from the stream. See [`quinn::RecvStream::read_chunks`].
+    pub async fn read_chunks(&mut self, bufs: &mut [Bytes]) -> Result<Option<usize>, ReadError> {
+        self.inner.read_chunks(bufs).await.map_err(Into::into)
+    }
+
+    /// Read until the end of the stream or the limit is hit. See [`quinn::RecvStream::read_to_end`].
+    pub async fn read_to_end(&mut self, size_limit: usize) -> Result<Vec<u8>, ReadToEndError> {
+        self.inner.read_to_end(size_limit).await.map_err(Into::into)
+    }
+
+    // We purposely don't expose the stream ID or 0RTT because it's not valid with WebTransport
+}
+
+impl tokio::io::AsyncRead for RecvStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl webtransport_generic::RecvStream for RecvStream {
+    type Error = ReadError;
+
+    fn poll_read_buf<B: bytes::BufMut>(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>> {
+        let dst = buf.chunk_mut();
+        let dst = unsafe { &mut *(dst as *mut _ as *mut [u8]) };
+
+        Poll::Ready(match ready!(pin!(RecvStream::read(self, dst)).poll(cx)) {
+            Ok(Some(n)) => unsafe {
+                buf.advance_mut(n);
+                Ok(n)
+            },
+            Ok(None) => Ok(0),
+            Err(err) => Err(err),
+        })
+    }
+
+    fn poll_read_chunk(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<Option<bytes::Bytes>, Self::Error>> {
+        Poll::Ready(
+            match ready!(pin!(RecvStream::read_chunk(self, usize::MAX, true)).poll(cx)) {
+                Ok(Some(chunk)) => Ok(Some(chunk.bytes)),
+                Ok(None) => Ok(None),
+                Err(e) => Err(e),
+            },
+        )
+    }
+
+    /// Send a `STOP_SENDING` QUIC code.
+    fn close(mut self, code: u32) {
+        self.stop(code).ok();
+    }
+}

--- a/webtransport-quinn/src/send.rs
+++ b/webtransport-quinn/src/send.rs
@@ -1,12 +1,13 @@
 use std::{
     io,
-    pin::Pin,
-    task::{Context, Poll},
+    pin::{pin, Pin},
+    task::{ready, Context, Poll},
 };
 
 use bytes::Bytes;
+use futures::Future;
 
-use crate::{ReadError, ReadExactError, ReadToEndError, StoppedError, StreamClosed, WriteError};
+use crate::{StoppedError, StreamClosed, WriteError};
 
 /// A stream that can be used to send bytes. See [`quinn::SendStream`].
 ///
@@ -100,84 +101,31 @@ impl tokio::io::AsyncWrite for SendStream {
 }
 
 impl webtransport_generic::SendStream for SendStream {
-    fn reset(&mut self, reset_code: u32) {
-        SendStream::reset(self, reset_code).ok();
+    type Error = WriteError;
+
+    fn poll_write(&mut self, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize, Self::Error>> {
+        pin!(SendStream::write(self, buf)).poll(cx)
     }
 
-    fn set_priority(&mut self, order: i32) {
-        SendStream::set_priority(self, order).ok();
-    }
-}
-
-/// A stream that can be used to recieve bytes. See [`quinn::RecvStream`].
-#[derive(Debug)]
-pub struct RecvStream {
-    inner: quinn::RecvStream,
-}
-
-impl RecvStream {
-    pub(crate) fn new(stream: quinn::RecvStream) -> Self {
-        Self { inner: stream }
-    }
-
-    /// Tell the other end to stop sending data with the given error code. See [`quinn::RecvStream::stop`].
-    /// This is a u32 with WebTransport since it shares the error space with HTTP/3.
-    pub fn stop(&mut self, code: u32) -> Result<(), quinn::UnknownStream> {
-        let code = webtransport_proto::error_to_http3(code);
-        let code = quinn::VarInt::try_from(code).unwrap();
-        self.inner.stop(code)
-    }
-
-    // Unfortunately, we have to wrap ReadError for a bunch of functions.
-
-    /// Read some data into the buffer and return the amount read. See [`quinn::RecvStream::read`].
-    pub async fn read(&mut self, buf: &mut [u8]) -> Result<Option<usize>, ReadError> {
-        self.inner.read(buf).await.map_err(Into::into)
-    }
-
-    /// Fill the entire buffer with data. See [`quinn::RecvStream::read_exact`].
-    pub async fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ReadExactError> {
-        self.inner.read_exact(buf).await.map_err(Into::into)
-    }
-
-    /// Read a chunk of data from the stream. See [`quinn::RecvStream::read_chunk`].
-    pub async fn read_chunk(
+    fn poll_write_buf<B: bytes::Buf>(
         &mut self,
-        max_length: usize,
-        ordered: bool,
-    ) -> Result<Option<quinn::Chunk>, ReadError> {
-        self.inner
-            .read_chunk(max_length, ordered)
-            .await
-            .map_err(Into::into)
-    }
-
-    /// Read chunks of data from the stream. See [`quinn::RecvStream::read_chunks`].
-    pub async fn read_chunks(&mut self, bufs: &mut [Bytes]) -> Result<Option<usize>, ReadError> {
-        self.inner.read_chunks(bufs).await.map_err(Into::into)
-    }
-
-    /// Read until the end of the stream or the limit is hit. See [`quinn::RecvStream::read_to_end`].
-    pub async fn read_to_end(&mut self, size_limit: usize) -> Result<Vec<u8>, ReadToEndError> {
-        self.inner.read_to_end(size_limit).await.map_err(Into::into)
-    }
-
-    // We purposely don't expose the stream ID or 0RTT because it's not valid with WebTransport
-}
-
-impl tokio::io::AsyncRead for RecvStream {
-    fn poll_read(
-        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
-        buf: &mut tokio::io::ReadBuf,
-    ) -> Poll<io::Result<()>> {
-        Pin::new(&mut self.inner).poll_read(cx, buf)
+        buf: &mut B,
+    ) -> Poll<Result<usize, Self::Error>> {
+        Poll::Ready(match ready!(self.poll_write(cx, buf.chunk())) {
+            Ok(n) => {
+                buf.advance(n);
+                Ok(n)
+            }
+            Err(e) => Err(e),
+        })
     }
-}
 
-impl webtransport_generic::RecvStream for RecvStream {
-    /// Send a `STOP_SENDING` QUIC code.
-    fn stop(&mut self, error_code: u32) {
-        self.stop(error_code).ok();
+    fn close(mut self, code: u32) {
+        SendStream::reset(&mut self, code).ok();
+    }
+
+    fn priority(&mut self, order: i32) {
+        SendStream::set_priority(self, order).ok();
     }
 }


### PR DESCRIPTION
Allows read_chunk to perform unbuffered reads.
It's also just nice to avoid the mess that is io::Error.